### PR TITLE
Cell draw no longer using cell.png

### DIFF
--- a/src/InventoryPreview/InventoryPreviewPlugin.cs
+++ b/src/InventoryPreview/InventoryPreviewPlugin.cs
@@ -89,11 +89,13 @@ namespace InventoryPreview
             float cellWidth = GetCellSize(cell.ItemSizeX);
             float cellHeight = GetCellSize(cell.ItemSizeY);
             var rectangleF = new RectangleF(d.X, d.Y, cellWidth, cellHeight);
-
-            Graphics.DrawImage("cell.png", rectangleF, cell.IsUsed ? Settings.CellUsedColor : Settings.CellFreeColor);
-
+            
+            //Graphics.DrawImage("cell.png", rectangleF, cell.IsUsed ? Settings.FullBackgroundColor : Settings.EmptyBackgroundColor);
             if (cell.IsUsed)
             {
+                Graphics.DrawBox(rectangleF, Settings.FullBackgroundColor);
+                Graphics.DrawFrame(rectangleF, Settings.CellBorderThickness, Settings.FullBorderColor);
+
                 if (!string.IsNullOrEmpty(cell.IconMetadata))
                 {
                     var getImg = GetImage(cell.IconMetadata);
@@ -116,11 +118,16 @@ namespace InventoryPreview
                     backgroundRect.Y += offset;
                     textPos.Y += offset;
 
-                    Graphics.DrawImage("menu-colors.png", backgroundRect, Settings.BackgroundColor);
-                    var color = cell.CurrentStackSize == cell.MaxStackSize ? new SharpDX.Color(0, 186, 154) : SharpDX.Color.White;
+                    Graphics.DrawImage("menu-colors.png", backgroundRect, Settings.TextBackgroundColor);
 
+                    var color = cell.CurrentStackSize == cell.MaxStackSize ? new SharpDX.Color(0, 186, 154) : SharpDX.Color.White;
                     Graphics.DrawText(cell.CurrentStackSize.ToString(), textSize, textPos, color, SharpDX.Direct3D9.FontDrawFlags.Center);
                 }
+            }
+            else
+            {
+                Graphics.DrawBox(rectangleF, Settings.EmptyBackgroundColor);
+                Graphics.DrawFrame(rectangleF, Settings.CellBorderThickness, Settings.EmptyBorderColor);
             }
 
 

--- a/src/InventoryPreview/InventoryPreviewSettings.cs
+++ b/src/InventoryPreview/InventoryPreviewSettings.cs
@@ -10,21 +10,37 @@ namespace InventoryPreview
         {
             Enable = false;
             AutoUpdate = true;
-            CellUsedColor = new Color(255, 0, 0, 255);
-            CellFreeColor = new Color(255, 255, 255, 255);
+            FullBorderColor = new Color(255, 0, 0, 255);
+            FullBackgroundColor = new Color(255, 0, 0, 255);
+            EmptyBorderColor = new Color(255, 255, 255, 255);
+            EmptyBackgroundColor = new Color(255, 255, 255, 255);
+            CellBorderThickness = new RangeNode<int>(1, 0, 10);
             CellSize = new RangeNode<int>(30, 1, 100);
             CellPadding = new RangeNode<int>(1, 0, 10);
             PositionX = new RangeNode<float>(28.0f, 0.0f, 100.0f);
             PositionY = new RangeNode<float>(83.0f, 0.0f, 100.0f);
-            BackgroundColor = new ColorBGRA(0, 0, 0, 178);
+            TextBackgroundColor = new ColorBGRA(0, 0, 0, 178);
         }
 
         [Menu("Auto Update")]
         public ToggleNode AutoUpdate { get; set; }
-        [Menu("Used Cell Color")]
-        public ColorNode CellUsedColor { get; set; }
-        [Menu("Free Cell Color")]
-        public ColorNode CellFreeColor { get; set; }
+        
+        [Menu("Full Cells", 2)]
+        public EmptyNode FullCells { get; set; }
+        [Menu("Border Color", 21, 2)]
+        public ColorNode FullBorderColor { get; set; }
+        [Menu("Background Color", 22, 2)]
+        public ColorNode FullBackgroundColor { get; set; }
+
+        [Menu("Empty Cells", 1)]
+        public EmptyNode EmptyCells { get; set; }
+        [Menu("Border Color", 11, 1)]
+        public ColorNode EmptyBorderColor { get; set; }
+        [Menu("Background Color", 12, 1)]
+        public ColorNode EmptyBackgroundColor { get; set; }
+
+        [Menu("Cell Border Thickness")]
+        public RangeNode<int> CellBorderThickness { get; set; }
         [Menu("Cell Size")]
         public RangeNode<int> CellSize { get; set; }
         [Menu("Cell Padding")]
@@ -34,6 +50,6 @@ namespace InventoryPreview
         [Menu("Position Y")]
         public RangeNode<float> PositionY { get; set; }
         [Menu("Text Background Color")]
-        public ColorNode BackgroundColor { get; set; }
+        public ColorNode TextBackgroundColor { get; set; }
     }
 }


### PR DESCRIPTION
Preview: http://puu.sh/xO57s/6348a7c685.jpg
Removes the stretching of cells that arnt square
cell borders/backgrounds now have own colors

Only issue, no padding makes a funny overlap by 1 px in cell borders.
padding = 1 fixes issue ofc.